### PR TITLE
Simplify gen-cert.sh

### DIFF
--- a/scripts/gen-cert.sh
+++ b/scripts/gen-cert.sh
@@ -7,9 +7,6 @@
 # CERN Search is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-openssl genrsa -des3 -passout pass:x -out nginx.pass.key 2048
-openssl rsa -passin pass:x -in nginx.pass.key -out nginx.key
-rm nginx.pass.key
-openssl req -new -key nginx.key -out nginx.csr \
-  -subj "/C=CH/ST=Geneve/L=Geneve/O=CERN/OU=IT Department/CN=Search as a Service"
-openssl x509 -req -days 365 -in nginx.csr -signkey nginx.key -out nginx.crt
+openssl req -x509 -nodes -newkey rsa:4096 \
+  -subj '/C=CH/ST=Geneve/L=Geneve/O=CERN/OU=IT Department/CN=Search as a Service' \
+  -keyout nginx.key -out nginx.crt


### PR DESCRIPTION
No need to run all those commands; openssl can do it with a single one :)

The CN should probably be the `$(hostname --fqdn)` or localhost though...

I also switched from 2048 bits to 4096 bits; I don't think there's a good reason nowadays to use smaller keys.